### PR TITLE
add callback to fs.writeFile

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,7 +147,11 @@ function postInstall(hash){
     config[hashKey] = hash;
 
     //only save new hash if packager install was successful
-    fs.writeFile(hashFile, JSON.stringify(config));
+    fs.writeFile(hashFile, JSON.stringify(config), (err) => {
+        if (err) {
+            console.log(err);
+        }
+    });
         
     if(prune){
         spawnProcessAndHandleClose('prune');


### PR DESCRIPTION
The callback argument for fs.writeFile seems to be enforced on newer versions of node. Without this argument the hash save fails and npm install runs each time as there is no saved hash to compare against.